### PR TITLE
Fix typo

### DIFF
--- a/kcsara-exams/Views/Home/Index.cshtml
+++ b/kcsara-exams/Views/Home/Index.cshtml
@@ -7,7 +7,7 @@
   <p>
     Select an exam from the list below. There is no time limit to take the exam, nor maximum attempts. When you do pass,
     you'll be provided a link to a certificate you may open and print out. If you provide an email address, you'll receive
-    a notice of your successfull attempt.
+    a notice of your successful attempt.
   </p>
   <ul>
     @foreach (var item in Model)


### PR DESCRIPTION
Successful has one L, not two.